### PR TITLE
Add Kotlin support for annotation screenshots

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/util/StepDefinitionAnnotationReader.java
+++ b/src/main/java/net/serenitybdd/cucumber/util/StepDefinitionAnnotationReader.java
@@ -31,7 +31,6 @@ public class StepDefinitionAnnotationReader {
 
     public TakeScreenshots getScreenshotPreferences() {
         if (stepDefinitionPath == null) { return TakeScreenshots.UNDEFINED; }
-
         List<Annotation> stepDefinitionAnnotations = annotationsIn(className(), methodName());
         return stepDefinitionAnnotations.stream()
                 .filter(annotation -> annotation instanceof Screenshots)
@@ -57,11 +56,11 @@ public class StepDefinitionAnnotationReader {
     }
 
     private String className() {
+        stepDefinitionPath=stepDefinitionPath.replaceFirst("^([^\\s]*)(\\s)","");
         int lastOpeningParentheses = stepDefinitionPath.lastIndexOf("(");
         String qualifiedMethodName = stepDefinitionPath.substring(0, lastOpeningParentheses);
         int endOfClassName = qualifiedMethodName.lastIndexOf(".");
-        String qualifiedClassName = stepDefinitionPath.substring(0, endOfClassName);
-        return qualifiedClassName;
+        return stepDefinitionPath.substring(0, endOfClassName);
     }
 
     private String methodName() {

--- a/src/main/java/net/serenitybdd/cucumber/util/StepDefinitionAnnotationReader.java
+++ b/src/main/java/net/serenitybdd/cucumber/util/StepDefinitionAnnotationReader.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.stream;
 
@@ -30,7 +32,9 @@ public class StepDefinitionAnnotationReader {
     }
 
     public TakeScreenshots getScreenshotPreferences() {
-        if (stepDefinitionPath == null) { return TakeScreenshots.UNDEFINED; }
+        if (stepDefinitionPath == null) {
+            return TakeScreenshots.UNDEFINED;
+        }
         List<Annotation> stepDefinitionAnnotations = annotationsIn(className(), methodName());
         return stepDefinitionAnnotations.stream()
                 .filter(annotation -> annotation instanceof Screenshots)
@@ -56,7 +60,10 @@ public class StepDefinitionAnnotationReader {
     }
 
     private String className() {
-        stepDefinitionPath=stepDefinitionPath.replaceFirst("^([^\\s]*)(\\s)","");
+        Matcher matcher = Pattern.compile("^(\\w*\\s)").matcher(stepDefinitionPath);
+        if (matcher.lookingAt()) {
+            stepDefinitionPath = matcher.replaceFirst("");
+        }
         int lastOpeningParentheses = stepDefinitionPath.lastIndexOf("(");
         String qualifiedMethodName = stepDefinitionPath.substring(0, lastOpeningParentheses);
         int endOfClassName = qualifiedMethodName.lastIndexOf(".");


### PR DESCRIPTION
When using Kotlin, the stepDefinitionPath includes the return type of methods if is not open, 
for example:
 ```kotlin
@Given("something")
    fun `a Kotlin method`() {}
```
will be `void package.a kotlin method` so it will fail trying to load the class.

I add a validation to check if the method starts with a word and an space and in that case ignore those. 