### PR TITLE
fix: null exception when using parallel batches/forks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ wrapper {
 
 test {
     include '**/When*'
+    include '**/Cucumber*'
+    include '**/ScenarioLineCount*'
     exclude '**/*$*'
     exclude '**/integration/**'
     exclude '**/samples/**'


### PR DESCRIPTION
# Description

This is a fix for #5. It seems like the main issue is using TestSourcesModel to obtain Features in CucumberScenarioLoader and ScenarioLineCountStatistics. From what I can see, TestSourcesModel can only be used to get Features if it has TestSourceRead event in its field already. In CucumberScenarioLoader and ScenarioLineCountStatistics prior to this fix, the fields in TestSourcesModal are all empty. For this fix, I only changed the way Features are obtained.

Aside from that, there was a line that collects to map that did nothing. I removed it. mapsForFeatures wasn't set, so I set that too.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added more tests in build.gradle. Not sure why those 2 lines aren't already there. I also installed locally and did e2e tests using both LineCount and MultiRunTest.

# Extra Note:

I notice that the documentation in serenity-bdd.github.io, specifically the section of how to configure failsafe plugin, does not mention the config reuseForks=false. Without it, I had many cases where all test splits go to one fork. When I have that config in, all forks get their shares.