### PR TITLE
fix: not found examples tags when running in parallel

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -97,7 +98,9 @@ public class CucumberScenarioLoader {
         if (Scenario.class.isAssignableFrom(scenario.getClass())) {
             return ((Scenario) scenario).getTags();
         } else {
-            return ((ScenarioOutline) scenario).getTags();
+            return Stream.of(((ScenarioOutline) scenario).getTags(), ((ScenarioOutline) scenario).getExamples()
+                .stream().flatMap(e -> e.getTags().stream()).collect(toList())).flatMap(Collection::stream)
+                .collect(Collectors.toList());
         }
     }
 

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoaderTest.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoaderTest.java
@@ -49,5 +49,14 @@ public class CucumberScenarioLoaderTest {
                                                                      .tags()));
     }
 
+    @Test
+    public void shouldIncludeExamplesTagsOntoScenarios() throws Exception {
+        WeightedCucumberScenarios weightedCucumberScenarios = new CucumberScenarioLoader(newArrayList(new URI("classpath:samples/tagged_example_tables.feature")), testStatistics).load();
 
+        assertThat(weightedCucumberScenarios.scenarios, contains(MatchingCucumberScenario.with()
+                                                                    .featurePath("tagged_example_tables.feature")
+                                                                    .feature("Tagged Tables")
+                                                                    .scenario("This scenario should have two tables")
+                                                                    .tags("@small", "@big")));
+    }
 }


### PR DESCRIPTION
# Description

Discussed in #5, seems like the existing logic for parallel running doesn't retrieve the tags from examples.

Small change to include the examples tags with scenario outlines tags.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test for this. Also installed locally and did e2e tests.