### PR TITLE
Fix: parallel tests are skipped due to differences in sort order

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/WeightedCucumberScenarios.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/WeightedCucumberScenarios.java
@@ -1,7 +1,5 @@
 package net.serenitybdd.cucumber.suiteslicing;
 
-import com.google.common.collect.Iterables;
-
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
@@ -16,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static java.math.BigDecimal.ZERO;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.compare;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
@@ -49,7 +46,7 @@ public class WeightedCucumberScenarios {
         List<List<WeightedCucumberScenario>> allScenarios = IntStream.rangeClosed(1, sliceCount).mapToObj(initialiseAs -> new ArrayList<WeightedCucumberScenario>()).collect(toList());
 
         scenarios.stream()
-            .sorted(bySlowestFirst())
+            .sorted(bySlowestFirst().thenComparing(byFeaturePathAscending()))
             .forEach(scenario -> allScenarios.stream().min(byLowestSumOfDurationFirst()).get().add(scenario));
 
         return allScenarios.stream().map(WeightedCucumberScenarios::new).collect(toList());
@@ -93,6 +90,13 @@ public class WeightedCucumberScenarios {
 
     private static Comparator<WeightedCucumberScenario> bySlowestFirst() {
         return (item1, item2) -> compare(item2.weighting(), item1.weighting());
+    }
+
+    /** Ensure the order of scenarios with the same weighting. This is to prevent scenarios getting skipped from
+     * batch or fork. Use featurePath due to unique file name.
+     * */
+    private static Comparator<WeightedCucumberScenario> byFeaturePathAscending() {
+        return (item1, item2) -> compare(item1.featurePath, item2.featurePath);
     }
 
     private static Comparator<List<WeightedCucumberScenario>> byLowestSumOfDurationFirst() {


### PR DESCRIPTION
#### Summary of this PR
This PR aims to fix the issue of skipping tests when running in batch/fork mode.

This issue happens intermittently, where tests would be skipped for no apparent reason. There seems to be no pattern at first, as sometimes all tests would run, and sometimes some would be skipped. Even the skipped tests are not the same for each run. With trial and error, I notice that this is due to how the scenarios are sorted, right before they get split up into each batch/fork. The scenarios are only sorted in descending order according to their weights, but scenarios with the same weights could end up in a different order each time the scenarios are loaded. Because the order of the scenarios with the same weights are not guaranteed, you could end up with same scenario being run more than 1 times, or skipped scenarios.

For example, assume we have 5 scenarios like so, after sorting for the 1st batch/fork
| Scenario  | Weight |
| ------------- | ------------- |
| s1  | 5  |
| s2  | 4  |
| s3  | 3  |
| s4  | 3  |
| s5  | 2  |

And we want to make this into 2 slices of size 3 and 2 with alternating scheme, so we could end up with these
Slice 1 - s1, s3, s5
Slice 2 - s2, s4

The 2nd batch/fork could have these scenarios order 
| Scenario  | Weight |
| ------------- | ------------- |
| s1  | 5  |
| s2  | 4  |
| s4  | 3 <--- different order from the 1st fork | 
| s3  | 3 <--- different order from the 1st fork |
| s5  | 2  |

Using the same number of slice and slicing scheme, we end up with
Slice 1 - s1, s4, s5
Slice 2 - s2, s3

So, the 1st fork would run s1, s3, and s5, and the 2nd fork would run s2 and s3. s3 would run twice and s4 would be skipped.

This fix simply add one more sorting function to the scenarios with the same weight using featurePath. I select featurePath because they are file name (typically same as feature tested) and likely to be unique. This is to ensure that all batches/forks would have the same scenarios order and slicing would work properly.
 
#### Intended effect
Currently, some tests (specifically tests with the same weights) would be skipped intermittently when running in parallel. This PR aims to fix that by ensuring the order of scenarios prior to slicing.
#### How should this be manually tested?
I have added unit test for this. You can verify this by commenting out the new sorting function and the test would fail because each fork would get different scenarios in its slices. For batch/fork to work properly, each batch/fork has to have the exact same scenarios in its slices.